### PR TITLE
Fix libraries.gradle for logback and java 8

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -1,7 +1,7 @@
 ext {
     jposVersion = '2.1.10-SNAPSHOT'
     slf4jVersion = '1.7.36'
-    logbackVersion = '1.5.6'
+    logbackVersion = '1.3.14'
     hibernateVersion = '5.6.15.Final'
     geronimoVersion = '1.1.1'
     jettyVersion = '9.4.54.v20240208'


### PR DESCRIPTION
1.5.x versions of logback lib are not compatible with java8. Downgrade to 1.3.x version